### PR TITLE
Fixed class path missing for haxelib use

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -4,5 +4,11 @@
   "classPath": "src",
   "releasenote": "",
   "url": "hhttps://github.com/Aidan63/ecs",
-  "dependencies": {}
+  "dependencies": {
+	  "promhx": "",
+	  "safety": "",
+	  "buddy": "",
+	  "bits": "",
+	  "asynctools": ""
+  }
 }

--- a/haxelib.json
+++ b/haxelib.json
@@ -1,0 +1,8 @@
+{
+  "name": "ecs",
+  "license": "MIT",
+  "classPath": "src",
+  "releasenote": "",
+  "url": "hhttps://github.com/Aidan63/ecs",
+  "dependencies": {}
+}


### PR DESCRIPTION
Not sure if this is the only way to fix this issue, but I went to use this in a headless application whilst installing via haxelib and wasn't able to access the package!