### PR TITLE
Throw error when entity limit exceeded

### DIFF
--- a/src/ecs/core/EntityManager.hx
+++ b/src/ecs/core/EntityManager.hx
@@ -26,6 +26,12 @@ class EntityManager
         }
 	   
         final idx = nextID++;
+	
+	if (idx >= storage.length)
+        {
+            throw "ECS entity limit exceeded";
+        }
+	
         final e   = new Entity(idx);
 
         storage[idx] = e;


### PR DESCRIPTION
I've had some bizarre looking bugs occur that end up being related to the entity count being exceeded. This error throw immediately removes any ambiguity as to what happened.

Though, I'm curious if others use the entity limit in a different way, like enforcing the limit rather than hoping you never reach it.