### PR TITLE
Respect phase disabled on start

### DIFF
--- a/src/ecs/Universe.hx
+++ b/src/ecs/Universe.hx
@@ -315,7 +315,7 @@ class Universe
                                     @:privateAccess phase.systems.set($v{ j }, s);
                                     @:privateAccess phase.enabledSystems.set($v{ j }, $v{ system.enabled });
 
-                                    $e{ if (system.enabled) macro s.onEnabled(); else macro null }
+                                    $e{ if (phase.enabled && system.enabled) macro s.onEnabled(); else macro null }
                                 };
                             }
                         ] }


### PR DESCRIPTION
Within `Universe.create()`, starting a phase off with `enabled : false` still results in all of its systems running their `onEnabled()`s. Because there is currently no way to disable an individual system, it's not otherwise possible to prevent a system's `onEnabled()`. Enabling the phase later causes the `onEnabled()`s to be called again.

This PR adds a `phase.enabled` check to the initial `onEnabled()` call, which should also work if eventually system disabling is implemented in `create()`.